### PR TITLE
chore: bump extension version to 1.4.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "YouTube Transcript Extractor",
-    "version": "1.3",
+    "version": "1.4.1",
     "description": "Automatically extract and summarize YouTube video transcripts with a simple popup interface.",
     "permissions": ["activeTab", "scripting"],
     "host_permissions": ["https://www.youtube.com/*"],


### PR DESCRIPTION
## Summary
- bump the extension manifest version to 1.4.1 to match the Chrome Web Store package

## Validation
- verified manifest.json now reports version 1.4.1
- packaged upload zip from the runtime files only