### PR TITLE
feat: refresh popup UI and add system theming

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -8,37 +8,22 @@
     </head>
 
     <body>
-        <div class="container">
-            <header class="top-bar">
-                <div class="title-group">
-                    <div class="header-title">YouTube Transcript</div>
-                    <div class="header-subtitle">Clip transcript into your notes</div>
+        <div class="shell">
+            <header class="toolbar">
+                <div class="app-mark" aria-hidden="true">
+                    <span class="app-mark-glyph"></span>
                 </div>
                 <div class="button-container">
+                    <div class="property-control" id="transcript-languages"></div>
+                    <button id="copy-transcript" class="button button-secondary">Copy</button>
                     <button id="extract-transcript" class="button button-primary">
                         Get Transcript
                     </button>
-                    <button id="copy-transcript" class="button button-secondary">Copy</button>
                 </div>
             </header>
-            <section class="panel">
-                <div class="panel-header">
-                    <span class="panel-title">Properties</span>
-                    <span class="panel-meta">Transcript language</span>
-                </div>
-                <div class="property-row">
-                    <div class="property-label">Language</div>
-                    <div class="property-control" id="transcript-languages"></div>
-                </div>
-            </section>
-            <section class="panel transcript-panel">
-                <div class="panel-header">
-                    <span class="panel-title">Transcript</span>
-                    <span class="panel-meta">Preview</span>
-                </div>
-                <div id="transcript-output" class="transcript-box"></div>
-            </section>
+
             <p id="message" class="message"></p>
+            <div id="transcript-output" class="transcript-box"></div>
         </div>
         <script type="module" src="popup.js"></script>
     </body>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,296 +1,283 @@
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600&display=swap');
-
 :root {
+    color-scheme: light dark;
+    --fs-11px: 0.688rem;
     --fs-12px: 0.75rem;
+    --fs-13px: 0.8125rem;
     --fs-14px: 0.875rem;
     --fs-16px: 1rem;
-    --fs-18px: 1.125rem;
-    --bg: #f6f7f5;
-    --surface: #ffffff;
-    --ink: #101315;
-    --muted: #6a7177;
-    --line: #e6e8ea;
-    --accent: #1f2a37;
-    --accent-weak: #eef1f4;
-    --error: #c0392b;
-    --font-sans: 'Space Grotesk', sans-serif;
-    --shadow-soft: 0 10px 24px rgba(16, 19, 21, 0.08);
-    --shadow-card: 0 12px 32px rgba(16, 19, 21, 0.06);
+    --bg: #eef2f5;
+    --surface: #f5f5f5;
+    --ink: #111827;
+    --muted: #6b7280;
+    --line: rgba(148, 163, 184, 0.22);
+    --line-strong: rgba(148, 163, 184, 0.34);
+    --accent: #101828;
+    --accent-contrast: #f8fafc;
+    --accent-soft: rgba(255, 255, 255, 0.62);
+    --error: #c2410c;
+    --message-bg: rgba(255, 247, 237, 0.95);
+    --focus-ring: rgba(24, 44, 71, 0.34);
+    --icon-bg: linear-gradient(180deg, #151b22 0%, #0f141a 100%);
+    --icon-glyph: linear-gradient(135deg, #f3f6fa 0%, #d4dbe4 100%);
+    --primary-bg: linear-gradient(180deg, #151d26 0%, #0f1720 100%);
+    --primary-shadow: 0 8px 18px rgba(15, 23, 42, 0.16);
+    --transcript-ink: #24303d;
+    --scrollbar: rgba(148, 163, 184, 0.52);
+    --scrollbar-hover: rgba(100, 116, 139, 0.72);
+    --spinner-track: rgba(148, 163, 184, 0.24);
+    --spinner-accent: #1d4ed8;
+    --font-sans: 'Avenir Next', 'Segoe UI', 'Helvetica Neue', sans-serif;
 }
 
-/* Ensure the popup has a minimum size */
-body,
-.container {
-    min-width: 420px;
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #11161c;
+        --surface: #171d24;
+        --ink: #eef2f7;
+        --muted: #a0acba;
+        --line: rgba(148, 163, 184, 0.16);
+        --line-strong: rgba(148, 163, 184, 0.28);
+        --accent: #f3f7fb;
+        --accent-contrast: #0f1720;
+        --accent-soft: rgba(255, 255, 255, 0.04);
+        --error: #fdba74;
+        --message-bg: rgba(124, 45, 18, 0.34);
+        --focus-ring: rgba(125, 170, 255, 0.42);
+        --icon-bg: linear-gradient(180deg, #f4f7fb 0%, #dfe7f0 100%);
+        --icon-glyph: linear-gradient(135deg, #0f1720 0%, #263241 100%);
+        --primary-bg: linear-gradient(180deg, #f4f7fb 0%, #dce6f0 100%);
+        --primary-shadow: 0 8px 18px rgba(0, 0, 0, 0.28);
+        --transcript-ink: #d7dee7;
+        --scrollbar: rgba(100, 116, 139, 0.52);
+        --scrollbar-hover: rgba(148, 163, 184, 0.76);
+        --spinner-track: rgba(148, 163, 184, 0.18);
+        --spinner-accent: #7dd3fc;
+    }
+}
+
+html,
+body {
     width: 100%;
     height: 100%;
+    min-width: 420px;
+}
+
+* {
     box-sizing: border-box;
 }
 
-/* Global Styles */
 body {
     margin: 0;
-    padding: 0;
     font-family: var(--font-sans);
-    background: #f7f8f9;
     color: var(--ink);
+    background: transparent;
     overflow: hidden;
 }
 
-/* Container for the layout */
-.container {
+.shell {
     display: grid;
-    grid-template-columns: 1fr;
-    grid-template-rows: auto auto 1fr auto;
+    grid-template-rows: auto auto 1fr;
+    gap: 12px;
     height: 100%;
-    box-sizing: border-box;
-    gap: 6px;
-    padding: 8px 10px 10px;
+    min-height: 520px;
+    padding: 14px;
+    background: var(--surface);
+    backdrop-filter: blur(10px);
     overflow: hidden;
 }
 
-/* Message styling */
-.message {
-    font-size: var(--fs-14px);
-    color: var(--error);
-    text-align: center;
-    padding: 4px 6px;
+.toolbar {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
 }
 
-/* Button styles */
+.app-mark {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 8px;
+    background: var(--icon-bg);
+}
+
+.app-mark-glyph {
+    width: 16px;
+    height: 16px;
+    border-radius: 5px;
+    background: var(--icon-glyph);
+    clip-path: polygon(
+        18% 18%,
+        82% 18%,
+        82% 38%,
+        52% 38%,
+        52% 54%,
+        82% 54%,
+        82% 82%,
+        18% 82%,
+        18% 62%,
+        48% 62%,
+        48% 46%,
+        18% 46%
+    );
+}
+
 .button-container {
-    display: flex;
+    min-width: 0;
+    flex-wrap: wrap;
     justify-content: flex-end;
+    display: flex;
     align-items: center;
     gap: 8px;
 }
 
 .button {
-    align-self: start;
-    background-color: var(--accent-weak);
     border: 1px solid var(--line);
-    border-radius: 10px;
-    color: var(--accent);
+    border-radius: 12px;
+    padding: 4px 8px;
+    font-size: var(--fs-11px);
+    font-weight: 600;
     cursor: pointer;
-    font-size: var(--fs-12px);
-    font-weight: 500;
-    letter-spacing: 0.02em;
-    padding: 5px 10px;
-    text-align: center;
     transition:
-        transform 0.2s ease,
-        background-color 0.2s ease,
-        border-color 0.2s ease,
-        box-shadow 0.2s ease;
+        transform 0.18s ease,
+        border-color 0.18s ease,
+        background-color 0.18s ease,
+        color 0.18s ease,
+        box-shadow 0.18s ease;
 }
 
 .button:disabled {
     cursor: not-allowed;
-    opacity: 0.5;
+    opacity: 0.48;
 }
 
 .button:hover:enabled {
-    background-color: var(--surface);
-    border-color: var(--accent);
     transform: translateY(-1px);
 }
 
-.button:focus-visible {
-    outline: 2px solid var(--accent);
+.button:focus-visible,
+.property-control select:focus-visible {
+    outline: 2px solid var(--focus-ring);
     outline-offset: 2px;
 }
 
 .button-primary {
-    background-color: var(--accent);
-    border-color: var(--accent);
-    color: var(--surface);
-    box-shadow: none;
-}
-
-.button-primary:hover:enabled {
-    background-color: #2b3847;
-    border-color: #2b3847;
+    border-color: transparent;
+    background: var(--primary-bg);
+    color: var(--accent-contrast);
+    box-shadow: var(--primary-shadow);
 }
 
 .button-secondary {
-    background-color: var(--accent-weak);
-    border-color: var(--line);
-}
-
-/* Loading spinner */
-.loading {
-    font-size: var(--fs-14px);
-    text-align: center;
-    color: var(--muted);
-}
-
-/* Transcript Header */
-.top-bar {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 6px 2px;
-    background-color: transparent;
-    border: none;
-    border-radius: 0;
-    box-shadow: none;
-    font-size: var(--fs-16px);
-    font-weight: 600;
-    color: var(--ink);
-}
-
-.title-group {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-}
-
-.header-title {
-    font-size: var(--fs-14px);
-    font-weight: 600;
-    letter-spacing: 0.02em;
-    color: var(--ink);
-}
-
-.header-subtitle {
-    font-size: var(--fs-12px);
-    color: var(--muted);
-}
-
-.panel {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 4px 2px;
-    background-color: transparent;
-    border: none;
-    border-radius: 0;
-    box-shadow: none;
-    min-height: 0;
-}
-
-.transcript-panel {
-    min-height: 0;
-}
-
-.panel-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    font-size: var(--fs-12px);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--muted);
-    padding-bottom: 4px;
-    border-bottom: 1px solid var(--line);
-}
-
-.panel-title {
-    font-weight: 600;
-}
-
-.panel-meta {
-    font-weight: 500;
-}
-
-.property-row {
-    display: grid;
-    grid-template-columns: 90px 1fr;
-    align-items: center;
-    gap: 8px;
-    padding: 4px 0;
-}
-
-.property-label {
-    font-size: var(--fs-12px);
-    color: var(--muted);
-    text-transform: lowercase;
+    background: var(--accent-soft);
+    color: var(--accent);
 }
 
 .property-control {
+    min-width: 0;
     display: flex;
     justify-content: flex-end;
+    align-self: center;
 }
 
 .property-control select {
-    font-size: var(--fs-12px);
-    padding: 4px 6px;
+    max-width: 100%;
+    min-width: 132px;
+    padding: 4px 8px;
+    border: 1px solid var(--line-strong);
     border-radius: 8px;
-    border: 1px solid var(--line);
-    background-color: var(--surface);
+    background: var(--accent-soft);
     color: var(--ink);
-    margin: 2px 0;
+    font-size: var(--fs-11px);
+    font-weight: 500;
 }
 
-.property-control select:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
+.message {
+    display: none;
+    margin: 0;
+    padding: 10px 12px;
+    border-radius: 12px;
+    background: var(--message-bg);
+    color: var(--error);
+    font-size: var(--fs-13px);
+    line-height: 1.45;
 }
 
-/* Transcript output box */
 .transcript-box {
-    background-color: transparent;
-    border: none;
-    border-radius: 0;
-    box-sizing: border-box;
-    font-size: var(--fs-14px);
-    font-weight: 400;
-    line-height: 1.6;
+    min-width: 0;
     min-height: 0;
-    max-height: none;
-    flex: 1 1 auto;
-    overflow-y: auto;
-    padding: 6px 2px;
-    text-align: left;
+    padding: 0;
+    background: transparent;
+    border: none;
+    font-size: var(--fs-14px);
+    line-height: 1.65;
+    color: var(--transcript-ink);
     white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    overflow-y: auto;
 }
 
-/* Scrollbar customization */
+.transcript-box strong {
+    max-width: 100%;
+    display: inline-block;
+    margin-bottom: 4px;
+    font-size: var(--fs-16px);
+    font-weight: 500;
+    color: var(--ink);
+}
+
 .transcript-box::-webkit-scrollbar {
-    width: 6px;
+    width: 8px;
+}
+
+.transcript-box::-webkit-scrollbar-track {
+    background: transparent;
 }
 
 .transcript-box::-webkit-scrollbar-thumb {
-    background-color: #c9cdd1;
-    border-radius: 10px;
+    border-radius: 999px;
+    background: var(--scrollbar);
 }
 
 .transcript-box::-webkit-scrollbar-thumb:hover {
-    background-color: #999;
+    background: var(--scrollbar-hover);
 }
 
-/* Spinner container to center only the spinner */
 .spinner-container {
-    align-items: center;
     display: flex;
     flex-direction: column;
+    align-items: center;
     justify-content: center;
-    height: 100%;
+    gap: 12px;
+    min-height: 100%;
+    color: var(--muted);
 }
 
-/* Spinner styles */
 .spinner {
-    animation: spin 1s linear infinite;
-    border: 4px solid rgba(0, 0, 0, 0.1);
-    border-left-color: var(--accent);
+    width: 28px;
+    height: 28px;
+    border: 3px solid var(--spinner-track);
+    border-top-color: var(--spinner-accent);
     border-radius: 50%;
-    opacity: 0.5;
-    height: 24px;
-    width: 24px;
-}
-
-/* Spinner animation */
-@keyframes spin {
-    0% {
-        transform: rotate(0deg);
-    }
-    100% {
-        transform: rotate(360deg);
-    }
+    animation: spin 0.9s linear infinite;
 }
 
 .spinner-text {
-    font-size: var(--fs-14px);
-    color: var(--muted);
-    margin-top: 8px;
+    max-width: 220px;
+    text-align: center;
+    font-size: var(--fs-13px);
+    line-height: 1.5;
+}
+
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
 }


### PR DESCRIPTION
## Summary
- simplify the popup layout into a flatter minimal surface
- refine control sizing and transcript layout to avoid nested card treatment
- add automatic light/dark theming using system color scheme

## Validation
- npx prettier --check src/popup.html styles/styles.css
- manual popup verification recommended in both light and dark system themes